### PR TITLE
sends funds directly to fundingRecipient

### DIFF
--- a/.changeset/beige-penguins-juggle.md
+++ b/.changeset/beige-penguins-juggle.md
@@ -1,0 +1,5 @@
+---
+'@soundxyz/protocol': minor
+---
+
+sends funds directly to fundingRecipient

--- a/.changeset/yellow-boats-film.md
+++ b/.changeset/yellow-boats-film.md
@@ -1,0 +1,5 @@
+---
+'@soundxyz/protocol': minor
+---
+
+Sends ETH directly to fundingRecipient during buyEdition call

--- a/protocol/contracts/ArtistV2.sol
+++ b/protocol/contracts/ArtistV2.sol
@@ -240,6 +240,17 @@ contract ArtistV2 is ERC721Upgradeable, IERC2981Upgradeable, OwnableUpgradeable 
         atTokenId.increment();
     }
 
+    function withdrawFunds(uint256 _editionId) external {
+        // Compute the amount available for withdrawing from this edition.
+        uint256 remainingForEdition = depositedForEdition[_editionId] - withdrawnForEdition[_editionId];
+
+        // Set the amount withdrawn to the amount deposited.
+        withdrawnForEdition[_editionId] = depositedForEdition[_editionId];
+
+        // Send the amount that was remaining for the edition, to the funding recipient.
+        _sendFunds(editions[_editionId].fundingRecipient, remainingForEdition);
+    }
+
     /// @notice Sets the start time for an edition
     function setStartTime(uint256 _editionId, uint32 _startTime) external onlyOwner {
         editions[_editionId].startTime = _startTime;

--- a/protocol/contracts/ArtistV2.sol
+++ b/protocol/contracts/ArtistV2.sol
@@ -71,9 +71,9 @@ contract ArtistV2 is ERC721Upgradeable, IERC2981Upgradeable, OwnableUpgradeable 
     mapping(uint256 => Edition) public editions;
     // Mapping of token id to edition id.
     mapping(uint256 => uint256) public tokenToEdition;
-    // <DEPRECATED IN V3> The amount of funds that have been deposited for a given edition.
+    // The amount of funds that have been deposited for a given edition.
     mapping(uint256 => uint256) public depositedForEdition;
-    // <DEPRECATED IN V3> The amount of funds that have already been withdrawn for a given edition.
+    // The amount of funds that have already been withdrawn for a given edition.
     mapping(uint256 => uint256) public withdrawnForEdition;
     // The presale typehash (used for checking signature validity)
     bytes32 public constant PRESALE_TYPEHASH =
@@ -223,17 +223,17 @@ contract ArtistV2 is ERC721Upgradeable, IERC2981Upgradeable, OwnableUpgradeable 
         // Don't allow purchases after the end time
         require(endTime > block.timestamp, 'Auction has ended');
 
-        // Send funds to the funding recipient.
-        _sendFunds(editions[_editionId].fundingRecipient, msg.value);
+        // Update the deposited total for the edition
+        depositedForEdition[_editionId] += msg.value;
 
         // Increment the number of tokens sold for this edition.
         editions[_editionId].numSold++;
 
-        // Store the mapping of token id to the edition being purchased.
-        tokenToEdition[atTokenId.current()] = _editionId;
-
         // Mint a new token for the sender, using the `tokenId`.
         _mint(msg.sender, atTokenId.current());
+
+        // Store the mapping of token id to the edition being purchased.
+        tokenToEdition[atTokenId.current()] = _editionId;
 
         emit EditionPurchased(_editionId, atTokenId.current(), editions[_editionId].numSold, msg.sender);
 

--- a/protocol/contracts/ArtistV3.sol
+++ b/protocol/contracts/ArtistV3.sol
@@ -73,7 +73,7 @@ contract ArtistV3 is ERC721Upgradeable, IERC2981Upgradeable, OwnableUpgradeable 
     mapping(uint256 => uint256) private _tokenToEdition;
     // The amount of funds that have been deposited for a given edition.
     mapping(uint256 => uint256) public depositedForEdition;
-    // The amount of funds that have already been withdrawn for a given edition.
+    // <DEPRECATED IN V3> The amount of funds that have already been withdrawn for a given edition.
     mapping(uint256 => uint256) public withdrawnForEdition;
     // The presale typehash (used for checking signature validity)
     bytes32 public constant PRESALE_TYPEHASH =
@@ -230,8 +230,8 @@ contract ArtistV3 is ERC721Upgradeable, IERC2981Upgradeable, OwnableUpgradeable 
         // Create the token id by packing editionId in the top bits
         uint256 tokenId = (_editionId << 128) | (numSold + 1);
 
-        // Update the deposited total for the edition
-        depositedForEdition[_editionId] += msg.value;
+        // Send funds to the funding recipient.
+        _sendFunds(editions[_editionId].fundingRecipient, msg.value);
 
         // Increment the number of tokens sold for this edition.
         editions[_editionId].numSold++;

--- a/protocol/test/Artist.test.ts
+++ b/protocol/test/Artist.test.ts
@@ -594,6 +594,35 @@ function testArtistContract(deployContract: Function, name: string) {
     });
   });
 
+  describe('withdrawFunds', () => {
+    it('transfers edition funds to the fundingRecipient', async () => {
+      const quantity = 10;
+      await setUpContract({ quantity: BigNumber.from(quantity) });
+
+      const [soundOwner, artistEOA, fundingRecipient, ...buyers] = await ethers.getSigners();
+      const originalRecipientBalance = await provider.getBalance(fundingRecipient.address);
+
+      for (let count = 1; count <= quantity; count++) {
+        const currentBuyer = buyers[count];
+        await artist.connect(currentBuyer).buyEdition(EDITION_ID, EMPTY_SIGNATURE, {
+          value: price,
+        });
+      }
+
+      // any address can call withdrawFunds
+      await artist.connect(soundOwner).withdrawFunds(EDITION_ID);
+
+      const contractBalance = await provider.getBalance(artist.address);
+      // All the funds are extracted.
+      await expect(contractBalance.toString()).to.eq('0');
+
+      const recipientBalance = await provider.getBalance(fundingRecipient.address);
+      const revenue = price.mul(quantity);
+
+      await expect(recipientBalance.toString()).to.eq(originalRecipientBalance.add(revenue));
+    });
+  });
+
   describe('setStartTime', () => {
     const newTime = currentSeconds() + 100;
 

--- a/protocol/test/Artist.test.ts
+++ b/protocol/test/Artist.test.ts
@@ -468,20 +468,21 @@ function testArtistContract(deployContract: Function, name: string) {
       }
     });
 
-    it('increments the balance of the contract', async () => {
+    it('increments the balance of the funding recipient', async () => {
       const quantity = 5;
       await setUpContract({ quantity: BigNumber.from(quantity) });
-      const [_, ...buyers] = await ethers.getSigners();
+      const signers = await ethers.getSigners();
+      const buyers = signers.slice(3);
+      const initialBalance = await provider.getBalance(fundingRecipient.address);
 
       for (let count = 1; count <= quantity; count++) {
         const revenue = price.mul(count);
         const currentBuyer = buyers[count];
-
         await artist.connect(currentBuyer).buyEdition(EDITION_ID, EMPTY_SIGNATURE, {
           value: price,
         });
-        const balance = await provider.getBalance(artist.address);
-        await expect(balance.toString()).to.eq(revenue.toString());
+        const finalBalance = await provider.getBalance(fundingRecipient.address);
+        expect(finalBalance.toString()).to.eq(revenue.add(initialBalance).toString());
       }
     });
 
@@ -590,35 +591,6 @@ function testArtistContract(deployContract: Function, name: string) {
       const purchase2Receipt = await purchase2.wait();
 
       await expect(purchase2Receipt.status).to.equal(1);
-    });
-  });
-
-  describe('withdrawFunds', () => {
-    it('transfers edition funds to the fundingRecipient', async () => {
-      const quantity = 10;
-      await setUpContract({ quantity: BigNumber.from(quantity) });
-
-      const [soundOwner, artistEOA, fundingRecipient, ...buyers] = await ethers.getSigners();
-      const originalRecipientBalance = await provider.getBalance(fundingRecipient.address);
-
-      for (let count = 1; count <= quantity; count++) {
-        const currentBuyer = buyers[count];
-        await artist.connect(currentBuyer).buyEdition(EDITION_ID, EMPTY_SIGNATURE, {
-          value: price,
-        });
-      }
-
-      // any address can call withdrawFunds
-      await artist.connect(soundOwner).withdrawFunds(EDITION_ID);
-
-      const contractBalance = await provider.getBalance(artist.address);
-      // All the funds are extracted.
-      await expect(contractBalance.toString()).to.eq('0');
-
-      const recipientBalance = await provider.getBalance(fundingRecipient.address);
-      const revenue = price.mul(quantity);
-
-      await expect(recipientBalance.toString()).to.eq(originalRecipientBalance.add(revenue));
     });
   });
 


### PR DESCRIPTION
part of the [Sound protocol Feb/Mar 2022 upgrade plan](https://www.notion.so/soundxyz/Limit-botters-flippers-upgrade-plan-895a5ed4d7914377beb7a0c7662b6da4?p=2b213e0ebbbc463fa2b45a3254454483&showMoveTo=true)

This is a UX improvement that trades slightly higher gas cost for buyers for the benefit of getting ETH into the artists' wallets with less friction. It's especially relevant for editions that are being split among multiple owners, as it reduces worse-case number of transactions required to withdraw from 3 to 2. 

Gas impact
- no more need to call `withdrawFunds` == 70k less gas **(~$20-30)**
- 6k less gas **(~$2-3)** per `buyEdition` for no longer needing to increment `depositedForEdition`
- ~21k *more* gas **($5-10)** per `buyEdition` for the `_sendFunds` call