### PR TITLE
Deprecates atTokenId in favor of bit-packed editionId with tokenId

### DIFF
--- a/.changeset/khaki-rocks-push.md
+++ b/.changeset/khaki-rocks-push.md
@@ -1,0 +1,5 @@
+---
+'@soundxyz/protocol': minor
+---
+
+Bitpacks editionId into top bits of tokenId

--- a/.changeset/nine-ligers-obey.md
+++ b/.changeset/nine-ligers-obey.md
@@ -1,0 +1,5 @@
+---
+'@soundxyz/protocol': minor
+---
+
+Deprecates atTokenId and in favor of bit-packed editionId with tokenId

--- a/protocol/contracts/ArtistV2.sol
+++ b/protocol/contracts/ArtistV2.sol
@@ -64,12 +64,12 @@ contract ArtistV2 is ERC721Upgradeable, IERC2981Upgradeable, OwnableUpgradeable 
 
     string internal baseURI;
 
-    CountersUpgradeable.Counter private atTokenId;
+    CountersUpgradeable.Counter private atTokenId; // DEPRECATED IN V3
     CountersUpgradeable.Counter private atEditionId;
 
     // Mapping of edition id to descriptive data.
     mapping(uint256 => Edition) public editions;
-    // Mapping of token id to edition id.
+    // <DEPRECATED IN V3> Mapping of token id to edition id.
     mapping(uint256 => uint256) public tokenToEdition;
     // The amount of funds that have been deposited for a given edition.
     mapping(uint256 => uint256) public depositedForEdition;
@@ -223,6 +223,9 @@ contract ArtistV2 is ERC721Upgradeable, IERC2981Upgradeable, OwnableUpgradeable 
         // Don't allow purchases after the end time
         require(endTime > block.timestamp, 'Auction has ended');
 
+        // Create the token id by packing editionId in the top bits
+        uint256 tokenId = (_editionId << 128) | (numSold + 1);
+
         // Update the deposited total for the edition
         depositedForEdition[_editionId] += msg.value;
 
@@ -230,14 +233,9 @@ contract ArtistV2 is ERC721Upgradeable, IERC2981Upgradeable, OwnableUpgradeable 
         editions[_editionId].numSold++;
 
         // Mint a new token for the sender, using the `tokenId`.
-        _mint(msg.sender, atTokenId.current());
+        _mint(msg.sender, tokenId);
 
-        // Store the mapping of token id to the edition being purchased.
-        tokenToEdition[atTokenId.current()] = _editionId;
-
-        emit EditionPurchased(_editionId, atTokenId.current(), editions[_editionId].numSold, msg.sender);
-
-        atTokenId.increment();
+        emit EditionPurchased(_editionId, tokenId, editions[_editionId].numSold, msg.sender);
     }
 
     function withdrawFunds(uint256 _editionId) external {
@@ -267,44 +265,16 @@ contract ArtistV2 is ERC721Upgradeable, IERC2981Upgradeable, OwnableUpgradeable 
     function tokenURI(uint256 _tokenId) public view override returns (string memory) {
         require(_exists(_tokenId), 'ERC721Metadata: URI query for nonexistent token');
 
-        // Concatenate the components, baseURI, editionId and tokenId, to create URI.
-        return string(abi.encodePacked(baseURI, tokenToEdition[_tokenId].toString(), '/', _tokenId.toString()));
+        uint256 editionId = tokenToEditionView(_tokenId);
+
+        // Concatenate the compoents, baseURI, editionId and tokenId, to create URI.
+        return string(abi.encodePacked(baseURI, editionId.toString(), '/', _tokenId.toString()));
     }
 
     /// @notice Returns contract URI used by Opensea. e.g. https://sound.xyz/api/metadata/[artistId]/storefront
     function contractURI() public view returns (string memory) {
         // Concatenate the components, baseURI, editionId and tokenId, to create URI.
         return string(abi.encodePacked(baseURI, 'storefront'));
-    }
-
-    /// @notice Get token ids for a given edition id
-    /// @param _editionId edition id
-    function getTokenIdsOfEdition(uint256 _editionId) public view returns (uint256[] memory) {
-        uint256[] memory tokenIdsOfEdition = new uint256[](editions[_editionId].numSold);
-        uint256 index = 0;
-
-        for (uint256 id = 1; id < atTokenId.current(); id++) {
-            if (tokenToEdition[id] == _editionId) {
-                tokenIdsOfEdition[index] = id;
-                index++;
-            }
-        }
-        return tokenIdsOfEdition;
-    }
-
-    /// @notice Get owners of a given edition id
-    /// @param _editionId edition id
-    function getOwnersOfEdition(uint256 _editionId) public view returns (address[] memory) {
-        address[] memory ownersOfEdition = new address[](editions[_editionId].numSold);
-        uint256 index = 0;
-
-        for (uint256 id = 1; id < atTokenId.current(); id++) {
-            if (tokenToEdition[id] == _editionId) {
-                ownersOfEdition[index] = ERC721Upgradeable.ownerOf(id);
-                index++;
-            }
-        }
-        return ownersOfEdition;
     }
 
     /// @notice Get royalty information for token
@@ -316,7 +286,7 @@ contract ArtistV2 is ERC721Upgradeable, IERC2981Upgradeable, OwnableUpgradeable 
         override
         returns (address fundingRecipient, uint256 royaltyAmount)
     {
-        uint256 editionId = tokenToEdition[_tokenId];
+        uint256 editionId = tokenToEditionView(_tokenId);
         Edition memory edition = editions[editionId];
 
         if (edition.fundingRecipient == address(0x0)) {
@@ -330,7 +300,11 @@ contract ArtistV2 is ERC721Upgradeable, IERC2981Upgradeable, OwnableUpgradeable 
 
     /// @notice The total number of tokens created by this contract
     function totalSupply() external view returns (uint256) {
-        return atTokenId.current() - 1; // because atTokenId is 1-indexed
+        uint256 total = 0;
+        for (uint256 id = 1; id < atEditionId.current(); id++) {
+            total += editions[id].numSold;
+        }
+        return total;
     }
 
     /// @notice Informs other contracts which interfaces this contract supports
@@ -343,6 +317,19 @@ contract ArtistV2 is ERC721Upgradeable, IERC2981Upgradeable, OwnableUpgradeable 
     {
         return
             type(IERC2981Upgradeable).interfaceId == _interfaceId || ERC721Upgradeable.supportsInterface(_interfaceId);
+    }
+
+    function tokenToEditionView(uint256 _tokenId) public view returns (uint256) {
+        // Check the top bits to see if the edition id is there
+        uint256 editionId = _tokenId >> 128;
+
+        // If edition ID is 0, then this edition was created before the V3 upgrade
+        if (editionId == 0) {
+            // get edition ID from storage
+            editionId = tokenToEdition[_tokenId];
+        }
+
+        return editionId;
     }
 
     // ================================

--- a/protocol/contracts/ArtistV3.sol
+++ b/protocol/contracts/ArtistV3.sol
@@ -64,12 +64,12 @@ contract ArtistV3 is ERC721Upgradeable, IERC2981Upgradeable, OwnableUpgradeable 
 
     string internal baseURI;
 
-    CountersUpgradeable.Counter private atTokenId;
+    CountersUpgradeable.Counter private atTokenId; // DEPRECATED IN V3
     CountersUpgradeable.Counter private atEditionId;
 
     // Mapping of edition id to descriptive data.
     mapping(uint256 => Edition) public editions;
-    // Mapping of token id to edition id.
+    // <DEPRECATED IN V3> Mapping of token id to edition id.
     mapping(uint256 => uint256) public tokenToEdition;
     // The amount of funds that have been deposited for a given edition.
     mapping(uint256 => uint256) public depositedForEdition;
@@ -227,6 +227,9 @@ contract ArtistV3 is ERC721Upgradeable, IERC2981Upgradeable, OwnableUpgradeable 
         // Don't allow purchases after the end time
         require(endTime > block.timestamp, 'Auction has ended');
 
+        // Create the token id by packing editionId in the top bits
+        uint256 tokenId = (_editionId << 128) | (numSold + 1);
+
         // Update the deposited total for the edition
         depositedForEdition[_editionId] += msg.value;
 
@@ -234,14 +237,9 @@ contract ArtistV3 is ERC721Upgradeable, IERC2981Upgradeable, OwnableUpgradeable 
         editions[_editionId].numSold++;
 
         // Mint a new token for the sender, using the `tokenId`.
-        _mint(msg.sender, atTokenId.current());
+        _mint(msg.sender, tokenId);
 
-        // Store the mapping of token id to the edition being purchased.
-        tokenToEdition[atTokenId.current()] = _editionId;
-
-        emit EditionPurchased(_editionId, atTokenId.current(), editions[_editionId].numSold, msg.sender);
-
-        atTokenId.increment();
+        emit EditionPurchased(_editionId, tokenId, editions[_editionId].numSold, msg.sender);
     }
 
     function withdrawFunds(uint256 _editionId) external {
@@ -289,47 +287,25 @@ contract ArtistV3 is ERC721Upgradeable, IERC2981Upgradeable, OwnableUpgradeable 
     // ================================
 
     /// @notice Returns token URI (metadata URL). e.g. https://sound.xyz/api/metadata/[artistId]/[editionId]/[tokenId]
+    /// @dev Concatenate the baseURI, editionId and tokenId, to create URI.
     function tokenURI(uint256 _tokenId) public view override returns (string memory) {
         require(_exists(_tokenId), 'ERC721Metadata: URI query for nonexistent token');
 
-        // Concatenate the components, baseURI, editionId and tokenId, to create URI.
-        return string(abi.encodePacked(baseURI, tokenToEdition[_tokenId].toString(), '/', _tokenId.toString()));
+        uint256 editionId = tokenToEditionView(_tokenId);
+
+        // If _tokenId is less than 2**128, it's a pre-V3 upgrade token and we can simply append it to the URI
+        if (_tokenId < 2**128) {
+            return string(abi.encodePacked(baseURI, editionId.toString(), '/', _tokenId.toString()));
+        }
+
+        // If _tokenId is larger than 2**128, it's a post-V3 upgrade token and we need to subtract the edition id to get the serial #
+        return string(abi.encodePacked(baseURI, editionId.toString(), '/', (_tokenId - (editionId << 128)).toString()));
     }
 
     /// @notice Returns contract URI used by Opensea. e.g. https://sound.xyz/api/metadata/[artistId]/storefront
     function contractURI() public view returns (string memory) {
         // Concatenate the components, baseURI, editionId and tokenId, to create URI.
         return string(abi.encodePacked(baseURI, 'storefront'));
-    }
-
-    /// @notice Get token ids for a given edition id
-    /// @param _editionId edition id
-    function getTokenIdsOfEdition(uint256 _editionId) public view returns (uint256[] memory) {
-        uint256[] memory tokenIdsOfEdition = new uint256[](editions[_editionId].numSold);
-        uint256 index = 0;
-
-        for (uint256 id = 1; id < atTokenId.current(); id++) {
-            if (tokenToEdition[id] == _editionId) {
-                tokenIdsOfEdition[index] = id;
-                index++;
-            }
-        }
-        return tokenIdsOfEdition;
-    }
-
-    /// @notice Get owners of a given edition id
-    /// @param _editionId edition id
-    function getOwnersOfEdition(uint256 _editionId) public view returns (address[] memory) {
-        address[] memory ownersOfEdition = new address[](editions[_editionId].numSold);
-        uint256 index = 0;
-
-        for (uint256 id = 1; id < atTokenId.current(); id++) {
-            if (tokenToEdition[id] == _editionId) {
-                ownersOfEdition[index] = ERC721Upgradeable.ownerOf(id);
-                index++;
-            }
-        }
-        return ownersOfEdition;
     }
 
     /// @notice Get royalty information for token
@@ -341,7 +317,7 @@ contract ArtistV3 is ERC721Upgradeable, IERC2981Upgradeable, OwnableUpgradeable 
         override
         returns (address fundingRecipient, uint256 royaltyAmount)
     {
-        uint256 editionId = tokenToEdition[_tokenId];
+        uint256 editionId = tokenToEditionView(_tokenId);
         Edition memory edition = editions[editionId];
 
         if (edition.fundingRecipient == address(0x0)) {
@@ -355,7 +331,11 @@ contract ArtistV3 is ERC721Upgradeable, IERC2981Upgradeable, OwnableUpgradeable 
 
     /// @notice The total number of tokens created by this contract
     function totalSupply() external view returns (uint256) {
-        return atTokenId.current() - 1; // because atTokenId is 1-indexed
+        uint256 total = 0;
+        for (uint256 id = 1; id < atEditionId.current(); id++) {
+            total += editions[id].numSold;
+        }
+        return total;
     }
 
     /// @notice Informs other contracts which interfaces this contract supports
@@ -375,8 +355,21 @@ contract ArtistV3 is ERC721Upgradeable, IERC2981Upgradeable, OwnableUpgradeable 
         return atEditionId.current() - 1; // because atEditionId is incremented after each edition is created
     }
 
+    function tokenToEditionView(uint256 _tokenId) public view returns (uint256) {
+        // Check the top bits to see if the edition id is there
+        uint256 editionId = _tokenId >> 128;
+
+        // If edition ID is 0, then this edition was created before the V3 upgrade
+        if (editionId == 0) {
+            // get edition ID from storage
+            editionId = tokenToEdition[_tokenId];
+        }
+
+        return editionId;
+    }
+
     // ================================
-    // PRIVATE FUNCTIONS
+    // FUNCTIONS - PRIVATE
     // ================================
 
     /// @notice Sends funds to an address

--- a/protocol/test/Artist.test.ts
+++ b/protocol/test/Artist.test.ts
@@ -457,12 +457,12 @@ function testArtistContract(deployContract: Function, name: string) {
       await setUpContract({ quantity: BigNumber.from(quantity) });
       const [_, ...buyers] = await ethers.getSigners();
 
-      for (let tokenCount = 1; tokenCount < quantity; tokenCount++) {
-        const currentBuyer = buyers[tokenCount];
-        await artist.connect(buyers[tokenCount]).buyEdition(EDITION_ID, EMPTY_SIGNATURE, {
+      for (let tokenSerialNum = 1; tokenSerialNum < quantity; tokenSerialNum++) {
+        const currentBuyer = buyers[tokenSerialNum];
+        await artist.connect(buyers[tokenSerialNum]).buyEdition(EDITION_ID, EMPTY_SIGNATURE, {
           value: price,
         });
-        const tokenId = getTokenId(EDITION_ID, tokenCount);
+        const tokenId = getTokenId(EDITION_ID, tokenSerialNum);
         const owner = await artist.ownerOf(tokenId);
         await expect(owner).to.eq(currentBuyer.address);
       }
@@ -486,21 +486,21 @@ function testArtistContract(deployContract: Function, name: string) {
     });
 
     it(`tokenURI returns expected string`, async () => {
-      const quantity = 5;
+      const quantity = 10;
       await setUpContract({ quantity: BigNumber.from(quantity), editionCount: 3 });
       const [_, ...buyers] = await ethers.getSigners();
       const editionId = 3;
 
-      for (let tokenCount = 1; tokenCount < quantity; tokenCount++) {
-        const currentBuyer = buyers[tokenCount];
+      for (let tokenSerialNum = 1; tokenSerialNum < quantity; tokenSerialNum++) {
+        const currentBuyer = buyers[tokenSerialNum % buyers.length];
 
         await artist.connect(currentBuyer).buyEdition(editionId, EMPTY_SIGNATURE, {
           value: price,
         });
 
-        const tokenId = getTokenId(editionId, tokenCount);
+        const tokenId = getTokenId(editionId, tokenSerialNum.toString());
         const resp = await artist.tokenURI(tokenId);
-        const tokenURI = `${BASE_URI}${EXAMPLE_ARTIST_ID}/${editionId}/${tokenId}`;
+        const tokenURI = `${BASE_URI}${EXAMPLE_ARTIST_ID}/${editionId}/${tokenSerialNum.toString()}`;
 
         await expect(resp).to.eq(tokenURI);
       }

--- a/protocol/test/helpers.ts
+++ b/protocol/test/helpers.ts
@@ -69,3 +69,9 @@ export const deployArtistImplementation = async (soundOwner: SignerWithAddress) 
 
   return protoArtist;
 };
+
+// shifts edition id to the left by 128 bits and adds the token id in the bottom bits
+export const getTokenId = (editionId: number | string, numSold: number | string) => {
+  const shiftFactor = BigNumber.from(1).mul(2).pow(128);
+  return BigNumber.from(editionId).mul(shiftFactor).add(numSold);
+};

--- a/protocol/test/upgrades.test.ts
+++ b/protocol/test/upgrades.test.ts
@@ -332,7 +332,7 @@ describe('Upgrades', () => {
         await totalSupplyTest(artistPreUpgradeProxy, editionCount, tokenQuantity);
       });
 
-      it('returns expected edition id from tokenToEditionView', async () => {
+      it('returns expected edition id from tokenToEdition', async () => {
         const editionCount = 5;
         const tokenQuantity = 10;
         await setUp({ editionCount });
@@ -354,7 +354,7 @@ describe('Upgrades', () => {
           for (let tokenSerialNum = 1; tokenSerialNum <= tokenQuantity; tokenSerialNum++) {
             tokenId++;
 
-            const editionId = await artistPreUpgradeProxy.tokenToEditionView(tokenId);
+            const editionId = await artistPreUpgradeProxy.tokenToEdition(tokenId);
 
             expect(editionId.toNumber()).to.equal(currentEditionId);
           }
@@ -378,7 +378,7 @@ describe('Upgrades', () => {
         await totalSupplyTest(artistPostUpgradeProxy, editionCount, tokenQuantity, true);
       });
 
-      it('returns expected edition id from tokenToEditionView', async () => {
+      it('returns expected edition id from tokenToEdition', async () => {
         const editionCount = 5;
         const tokenQuantity = 10;
         await setUp();
@@ -387,13 +387,12 @@ describe('Upgrades', () => {
         await createEditions(artistPostUpgradeProxy, editionCount, true);
 
         for (let currentEditionId = 1; currentEditionId <= editionCount; currentEditionId++) {
-          console.log({ currentEditionId });
           for (let tokenSerialNum = 1; tokenSerialNum <= tokenQuantity; tokenSerialNum++) {
             // Buy token of edition
             await artistPostUpgradeProxy.buyEdition(currentEditionId, EMPTY_SIGNATURE, { value: price });
 
             const tokenId = getTokenId(currentEditionId, tokenSerialNum);
-            const editionId = await artistPostUpgradeProxy.tokenToEditionView(tokenId);
+            const editionId = await artistPostUpgradeProxy.tokenToEdition(tokenId);
 
             expect(editionId.toNumber()).to.equal(currentEditionId);
           }


### PR DESCRIPTION
part of the [Sound protocol Feb/Mar 2022 upgrade plan](https://www.notion.so/soundxyz/Limit-botters-flippers-upgrade-plan-895a5ed4d7914377beb7a0c7662b6da4?p=2b213e0ebbbc463fa2b45a3254454483&showMoveTo=true)

ticket: https://app.zenhub.com/workspaces/sound-collective-61145bc304834d0011a76588/issues/soundxyz/code/2406

## Goal
The primary goal of this PR is to reduce the gas impact of `buyEdition` and deprecate `tokenToEdition` mapping. It also sets us up for the next upgrade, which is to change our signature scheme to limit botting & flipping.

## What it includes:
- deprecates `atTokenId`
- packs `editionId` into the top 128 bits of `tokenId` so we only need the latter to know the former
- replaces `tokenToEdition` mapping with `tokenToEditionView` helper function to return the `editionId` for a given `tokenId` 
- changes `tokenURI` to return correct URI for both pre and post upgrade editions
- changes `totalSupply` to return the summed `numSold` for all editions

credit to @pvienhage for the awesome ideas