### PR TITLE
Adds getTokensOfEdition helper

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -12,7 +12,9 @@
     "postpublish": "gh-release"
   },
   "dependencies": {
+    "@ethersproject/bignumber": "^5.5.0",
     "@ethersproject/wallet": "^5.5.0",
+    "@soundxyz/protocol": "^3.4.0",
     "ethers": "^5.4.7",
     "slugify": "^1.6.0",
     "uuid": "^8.3.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,8 +56,10 @@ importers:
 
   common:
     specifiers:
+      '@ethersproject/bignumber': ^5.5.0
       '@ethersproject/providers': ^5.5.3
       '@ethersproject/wallet': ^5.5.0
+      '@soundxyz/protocol': ^3.4.0
       '@types/node': ^17.0.15
       '@types/uuid': ^8.3.3
       bob-ts: ^3.0.2
@@ -68,7 +70,9 @@ importers:
       typescript: ^4.5.4
       uuid: ^8.3.2
     dependencies:
+      '@ethersproject/bignumber': 5.5.0
       '@ethersproject/wallet': 5.5.0
+      '@soundxyz/protocol': link:../protocol
       ethers: 5.5.4
       slugify: 1.6.5
       uuid: 8.3.2


### PR DESCRIPTION
`npx bob-tsm src/index.ts --watch *` results in:

```
Error [ERR_UNSUPPORTED_DIR_IMPORT]: Directory import '/Users/masurka/SOUND_XYZ/protocol-public/common/node_modules/@soundxyz/protocol/typechain' is not supported resolving ES modules imported from /Users/masurka/SOUND_XYZ/protocol-public/common/src/helpers.ts
...
```

And if I run `pnpm prepack` and `node dist`, I get: 
```
node:internal/modules/cjs/loader:936
  throw err;
  ^

Error: Cannot find module '@soundxyz/protocol/typechain'
...
```