### PR TITLE
revert tokenURI change

### DIFF
--- a/protocol/contracts/ArtistV3.sol
+++ b/protocol/contracts/ArtistV3.sol
@@ -303,13 +303,7 @@ contract ArtistV3 is ERC721Upgradeable, IERC2981Upgradeable, OwnableUpgradeable 
 
         uint256 editionId = tokenToEdition(_tokenId);
 
-        // If _tokenId is less than 2**128, it's a pre-V3 upgrade token and we can simply append it to the URI
-        if (_tokenId < 2**128) {
-            return string(abi.encodePacked(baseURI, editionId.toString(), '/', _tokenId.toString()));
-        }
-
-        // If _tokenId is larger than 2**128, it's a post-V3 upgrade token and we need to subtract the edition id to get the serial #
-        return string(abi.encodePacked(baseURI, editionId.toString(), '/', (_tokenId - (editionId << 128)).toString()));
+        return string(abi.encodePacked(baseURI, editionId.toString(), '/', _tokenId.toString()));
     }
 
     /// @notice Returns contract URI used by Opensea. e.g. https://sound.xyz/api/metadata/[artistId]/storefront

--- a/protocol/test/Artist.test.ts
+++ b/protocol/test/Artist.test.ts
@@ -558,7 +558,7 @@ function testArtistContract(deployContract: Function, name: string) {
 
         const tokenId = getTokenId(editionId, tokenSerialNum.toString());
         const resp = await artist.tokenURI(tokenId);
-        const tokenURI = `${BASE_URI}${EXAMPLE_ARTIST_ID}/${editionId}/${tokenSerialNum.toString()}`;
+        const tokenURI = `${BASE_URI}${EXAMPLE_ARTIST_ID}/${editionId}/${tokenId.toString()}`;
 
         await expect(resp).to.eq(tokenURI);
       }


### PR DESCRIPTION
the downside of this is pre-upgrade tokenURIs will be like `...api/metadata/1/1/1` and post-upgrade will be like `...api/metadata/1/1/3907309379307007101`, but making them consistent would require including a version number in the URI so our API knows if it should search for the NFT using the `tokenId` or the `serialNumber`